### PR TITLE
fix: prop validation for image pipeline

### DIFF
--- a/API.md
+++ b/API.md
@@ -778,9 +778,9 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.imagePipelineArn">imagePipelineArn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.imagePipelineTopic">imagePipelineTopic</a></code> | <code>aws-cdk-lib.aws_sns.ITopic</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.latestAmi">latestAmi</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.imagePipelineArn">imagePipelineArn</a></code> | <code>string</code> | The Amazon Resource Name (ARN) of the Image Pipeline. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.imagePipelineTopic">imagePipelineTopic</a></code> | <code>aws-cdk-lib.aws_sns.ITopic</code> | The SNS Topic associated with this Image Pipeline. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.latestAmi">latestAmi</a></code> | <code>string</code> | The latest AMI built by the pipeline. |
 
 ---
 
@@ -804,6 +804,10 @@ public readonly imagePipelineArn: string;
 
 - *Type:* string
 
+The Amazon Resource Name (ARN) of the Image Pipeline.
+
+Used to uniquely identify this image pipeline.
+
 ---
 
 ##### `imagePipelineTopic`<sup>Required</sup> <a name="imagePipelineTopic" id="@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.imagePipelineTopic"></a>
@@ -814,6 +818,10 @@ public readonly imagePipelineTopic: ITopic;
 
 - *Type:* aws-cdk-lib.aws_sns.ITopic
 
+The SNS Topic associated with this Image Pipeline.
+
+Publishes notifications about pipeline execution events.
+
 ---
 
 ##### `latestAmi`<sup>Optional</sup> <a name="latestAmi" id="@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.property.latestAmi"></a>
@@ -823,6 +831,12 @@ public readonly latestAmi: string;
 ```
 
 - *Type:* string
+
+The latest AMI built by the pipeline.
+
+NOTE: You must have enabled the
+Build Configuration option to wait for image build completion for this
+property to be available.
 
 ---
 
@@ -2663,7 +2677,7 @@ const ec2LinuxImagePipelineProps: patterns.Ec2LinuxImagePipelineProps = { ... }
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.vpcConfiguration">vpcConfiguration</a></code> | <code>@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.VpcConfigurationProps</code> | VPC configuration for the image pipeline. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.extraComponents">extraComponents</a></code> | <code>@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.Component \| aws-cdk-lib.aws_imagebuilder.CfnComponent[]</code> | Additional components to install in the image. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.extraDeviceMappings">extraDeviceMappings</a></code> | <code>aws-cdk-lib.aws_imagebuilder.CfnImageRecipe.InstanceBlockDeviceMappingProperty[]</code> | Additional EBS volume mappings to add to the image. |
-| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.features">features</a></code> | <code>@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.Feature[]</code> | A list of features to install. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.features">features</a></code> | <code>@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.Feature[]</code> | A list of features to install on the image. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.operatingSystem">operatingSystem</a></code> | <code>@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.OperatingSystem</code> | The operating system to use for the image pipeline. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipelineProps.property.rootVolumeSize">rootVolumeSize</a></code> | <code>number</code> | Size for the root volume in GB. |
 
@@ -2768,7 +2782,8 @@ public readonly extraComponents: Component | CfnComponent[];
 
 Additional components to install in the image.
 
-These will be added after the default Linux components.
+These components will be added after the default Linux components.
+Use this to add custom components beyond the predefined features.
 
 ---
 
@@ -2782,7 +2797,8 @@ public readonly extraDeviceMappings: InstanceBlockDeviceMappingProperty[];
 
 Additional EBS volume mappings to add to the image.
 
-These will be added in addition to the root volume.
+These volumes will be added in addition to the root volume.
+Use this to specify additional storage volumes that should be included in the AMI.
 
 ---
 
@@ -2793,8 +2809,12 @@ public readonly features: Feature[];
 ```
 
 - *Type:* @cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.Feature[]
+- *Default:* [Ec2LinuxImagePipeline.Feature.AWS_CLI, Ec2LinuxImagePipeline.Feature.RETAIN_SSM_AGENT]
 
-A list of features to install.
+A list of features to install on the image.
+
+Features are predefined sets of components and configurations.
+Default: [AWS_CLI, RETAIN_SSM_AGENT]
 
 ---
 
@@ -2805,8 +2825,12 @@ public readonly operatingSystem: OperatingSystem;
 ```
 
 - *Type:* @cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.OperatingSystem
+- *Default:* Ec2LinuxImagePipeline.OperatingSystem.AMAZON_LINUX_2023
 
 The operating system to use for the image pipeline.
+
+Specifies which operating system version to use as the base image.
+Default: AMAZON_LINUX_2023.
 
 ---
 

--- a/src/constructs/ec2-image-builder-start/index.ts
+++ b/src/constructs/ec2-image-builder-start/index.ts
@@ -22,6 +22,10 @@ import { DefaultConfig } from '../../common/default-config';
 import { validate, ValidationTypes } from '../../common/validate';
 import { LambdaConfiguration } from '../../types/lambda-configuration';
 import { SecureFunction } from '../secure-function';
+import {
+    Ec2ImageBuilderStartHashError,
+    Ec2ImageBuilderStartTimeoutError
+} from './types/exception';
 
 /**
  * Properties for the EC2 Image Builder Start custom resource
@@ -117,10 +121,10 @@ export class Ec2ImageBuilderStart extends Construct {
         super(scope, id);
 
         if ((props.waitForCompletion?.timeout?.toSeconds() ?? 0) > 43200) {
-            throw new Error('Timeout cannot exceed 12 hours');
+            throw new Ec2ImageBuilderStartTimeoutError();
         }
         if ((props.hash?.length ?? 0) > 7) {
-            throw new Error('Hash must be 7 characters or less');
+            throw new Ec2ImageBuilderStartHashError();
         }
         validate(props.pipelineArn, ValidationTypes.AWS_ARN);
 

--- a/src/constructs/ec2-image-builder-start/types/exception.ts
+++ b/src/constructs/ec2-image-builder-start/types/exception.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export class Ec2ImageBuilderStartTimeoutError extends Error {
+    constructor() {
+        super('Timeout cannot exceed 12 hours');
+        this.name = 'Ec2ImageBuilderStartTimeoutError';
+    }
+}
+
+export class Ec2ImageBuilderStartHashError extends Error {
+    constructor() {
+        super('Hash must be 7 characters or less');
+        this.name = 'Ec2ImageBuilderStartHashError';
+    }
+}

--- a/src/constructs/ec2-image-pipeline/index.ts
+++ b/src/constructs/ec2-image-pipeline/index.ts
@@ -33,7 +33,7 @@ import { validate, ValidationTypes } from '../../common/validate';
 import { LambdaConfiguration } from '../../types';
 import { Ec2ImageBuilderGetImage } from '../ec2-image-builder-get-image';
 import { Ec2ImageBuilderStart } from '../ec2-image-builder-start';
-import { Ec2ImagePipelineBuildError } from './types/exception';
+import { Ec2ImagePipelineBuildConfigError } from './types/exception';
 
 /**
  * Base properties for EC2 Image Pipeline configuration.
@@ -146,7 +146,7 @@ export class Ec2ImagePipeline extends Construct {
      */
     public get latestAmi(): string | undefined {
         if (!this._buildConfigured) {
-            throw new Ec2ImagePipelineBuildError();
+            throw new Ec2ImagePipelineBuildConfigError();
         }
         return this._latestAmi;
     }

--- a/src/constructs/ec2-image-pipeline/index.ts
+++ b/src/constructs/ec2-image-pipeline/index.ts
@@ -33,6 +33,7 @@ import { validate, ValidationTypes } from '../../common/validate';
 import { LambdaConfiguration } from '../../types';
 import { Ec2ImageBuilderGetImage } from '../ec2-image-builder-get-image';
 import { Ec2ImageBuilderStart } from '../ec2-image-builder-start';
+import { Ec2ImagePipelineBuildError } from './types/exception';
 
 /**
  * Base properties for EC2 Image Pipeline configuration.
@@ -145,9 +146,7 @@ export class Ec2ImagePipeline extends Construct {
      */
     public get latestAmi(): string | undefined {
         if (!this._buildConfigured) {
-            throw new Error(
-                'Cannot access the `latestAmi` property of the Image Pipeline without configuring buildConfiguration.start and buildConfiguration.waitForCompletion as true.'
-            );
+            throw new Ec2ImagePipelineBuildError();
         }
         return this._latestAmi;
     }

--- a/src/constructs/ec2-image-pipeline/types/exception.ts
+++ b/src/constructs/ec2-image-pipeline/types/exception.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export class Ec2ImagePipelineBuildError extends Error {
+export class Ec2ImagePipelineBuildConfigError extends Error {
     constructor() {
         super(
             'Cannot access the `latestAmi` property of the Image Pipeline without configuring buildConfiguration.start and buildConfiguration.waitForCompletion as true.'

--- a/src/constructs/ec2-image-pipeline/types/exception.ts
+++ b/src/constructs/ec2-image-pipeline/types/exception.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export class Ec2ImagePipelineBuildError extends Error {
+    constructor() {
+        super(
+            'Cannot access the `latestAmi` property of the Image Pipeline without configuring buildConfiguration.start and buildConfiguration.waitForCompletion as true.'
+        );
+        this.name = 'Ec2ImagePipelineBuildError';
+    }
+}

--- a/test/constructs/ec2-image-pipeline/index.test.ts
+++ b/test/constructs/ec2-image-pipeline/index.test.ts
@@ -7,8 +7,8 @@ import { SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { CfnComponent } from 'aws-cdk-lib/aws-imagebuilder';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Ec2ImagePipeline } from '../../../src/constructs/ec2-image-pipeline';
-import { describeCdkTest } from '../../../utilities/cdk-nag-jest';
 import { Ec2ImagePipelineBuildConfigError } from '../../../src/constructs/ec2-image-pipeline/types/exception';
+import { describeCdkTest } from '../../../utilities/cdk-nag-jest';
 
 describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
     let stack: Stack;

--- a/test/constructs/ec2-image-pipeline/index.test.ts
+++ b/test/constructs/ec2-image-pipeline/index.test.ts
@@ -144,7 +144,9 @@ describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
         });
 
         // Assert
-        expect(imagePipeline.latestAmi).toBeUndefined();
+        expect(() => imagePipeline.latestAmi).toThrow(
+            'Cannot access the `latestAmi` property of the Image Pipeline without configuring buildConfiguration.start and buildConfiguration.waitForCompletion as true.'
+        );
     });
 
     it('creates image pipeline with custom CfnComponent', () => {

--- a/test/constructs/ec2-image-pipeline/index.test.ts
+++ b/test/constructs/ec2-image-pipeline/index.test.ts
@@ -8,6 +8,7 @@ import { CfnComponent } from 'aws-cdk-lib/aws-imagebuilder';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Ec2ImagePipeline } from '../../../src/constructs/ec2-image-pipeline';
 import { describeCdkTest } from '../../../utilities/cdk-nag-jest';
+import { Ec2ImagePipelineBuildError } from '../../../src/constructs/ec2-image-pipeline/types/exception';
 
 describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
     let stack: Stack;
@@ -145,7 +146,7 @@ describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
 
         // Assert
         expect(() => imagePipeline.latestAmi).toThrow(
-            'Cannot access the `latestAmi` property of the Image Pipeline without configuring buildConfiguration.start and buildConfiguration.waitForCompletion as true.'
+            Ec2ImagePipelineBuildError
         );
     });
 

--- a/test/constructs/ec2-image-pipeline/index.test.ts
+++ b/test/constructs/ec2-image-pipeline/index.test.ts
@@ -8,7 +8,7 @@ import { CfnComponent } from 'aws-cdk-lib/aws-imagebuilder';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Ec2ImagePipeline } from '../../../src/constructs/ec2-image-pipeline';
 import { describeCdkTest } from '../../../utilities/cdk-nag-jest';
-import { Ec2ImagePipelineBuildError } from '../../../src/constructs/ec2-image-pipeline/types/exception';
+import { Ec2ImagePipelineBuildConfigError } from '../../../src/constructs/ec2-image-pipeline/types/exception';
 
 describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
     let stack: Stack;
@@ -146,7 +146,7 @@ describeCdkTest(Ec2ImagePipeline, (id, getStack, getTemplate) => {
 
         // Assert
         expect(() => imagePipeline.latestAmi).toThrow(
-            Ec2ImagePipelineBuildError
+            Ec2ImagePipelineBuildConfigError
         );
     });
 

--- a/test/patterns/ec2-linux-stig-image-pipeline/index.test.ts
+++ b/test/patterns/ec2-linux-stig-image-pipeline/index.test.ts
@@ -291,4 +291,29 @@ describeCdkTest(Ec2LinuxImagePipeline, (id, getStack, getTemplate) => {
             });
         }).toThrow(FeatureError);
     });
+
+    it('sets latestAmi and uses the getter from Ec2ImagePipeline', () => {
+        // Act
+        const pipeline = new Ec2LinuxImagePipeline(stack, id, {
+            version: '0.1.0',
+            buildConfiguration: {
+                start: true,
+                waitForCompletion: true
+            }
+        });
+
+        // Assert
+        expect(pipeline.latestAmi).toBeDefined();
+    });
+
+    it('throws a feature error on incompatible operating systems', () => {
+        expect(() => {
+            new Ec2LinuxImagePipeline(stack, id, {
+                version: '0.1.0',
+                operatingSystem:
+                    Ec2LinuxImagePipeline.OperatingSystem.AMAZON_LINUX_2023,
+                features: [Ec2LinuxImagePipeline.Feature.SCAP]
+            });
+        }).toThrow(FeatureError);
+    });
 });


### PR DESCRIPTION
- adds property validation for `latestAmi` to inform the user that they must set required props for it to be available
- add more tests for better coverage