### PR TITLE
fix: Silence HTTP request logging in the APIGW Static Hosting Pattern Tests

### DIFF
--- a/src/patterns/apigateway-static-hosting/handler/hosts/common/index.ts
+++ b/src/patterns/apigateway-static-hosting/handler/hosts/common/index.ts
@@ -88,7 +88,9 @@ export abstract class CommonHost<
         const app = express();
 
         // Configure default logging
-        app.use(morgan('combined'));
+        if (!this.props.disableHttpLogging) {
+            app.use(morgan('combined'));
+        }
 
         // First, try to load the URI as a static asset
         app.use(this.fileHandler);

--- a/src/patterns/apigateway-static-hosting/handler/types/configuration.ts
+++ b/src/patterns/apigateway-static-hosting/handler/types/configuration.ts
@@ -23,6 +23,13 @@ export interface CommonHostingConfiguration {
      * @default undefined Loads from the root of the store
      */
     readonly staticFilePath?: string;
+
+    /**
+     * If specified, the host will not log any HTTP requests
+     *
+     * @default false
+     */
+    readonly disableHttpLogging?: boolean;
 }
 
 /**

--- a/test/patterns/apigateway-static-hosting/handler/hosts/inline/index.test.ts
+++ b/test/patterns/apigateway-static-hosting/handler/hosts/inline/index.test.ts
@@ -9,6 +9,10 @@ import {
     InlineHostingConfiguration
 } from '../../../../../../src/patterns/apigateway-static-hosting/handler/hosts/inline';
 
+const commonConfig: Partial<InlineHostingConfiguration> = {
+    disableHttpLogging: true
+};
+
 // Must be relative to source file since __dirname is used
 const relativeFixturesDir = join(
     '..',
@@ -28,7 +32,9 @@ describe('API Gateway Static Hosting Handler (Inline Host)', () => {
     describe('Default Configuration', () => {
         it('Should return 404 if asset directory is set incorrectly', async () => {
             // Arrange
-            const app = new InlineHost().create();
+            const app = new InlineHost({
+                ...commonConfig
+            }).create();
 
             // Act
             const response = await request(app).get('/assets/sample.txt');
@@ -40,6 +46,7 @@ describe('API Gateway Static Hosting Handler (Inline Host)', () => {
 
     describe('SPA', () => {
         const inlineSpaEnvironment: InlineHostingConfiguration = {
+            ...commonConfig,
             spaIndexPage: 'outer.html',
             staticFilePath: relativeFixturesDir
         };
@@ -71,6 +78,7 @@ describe('API Gateway Static Hosting Handler (Inline Host)', () => {
 
     describe('Not SPA', () => {
         const inlineNonSpaEnvironment: InlineHostingConfiguration = {
+            ...commonConfig,
             staticFilePath: relativeFixturesDir
         };
 

--- a/test/patterns/apigateway-static-hosting/handler/hosts/s3/index.test.ts
+++ b/test/patterns/apigateway-static-hosting/handler/hosts/s3/index.test.ts
@@ -17,6 +17,10 @@ import {
 } from '../../../../../../src/patterns/apigateway-static-hosting/handler/hosts/s3';
 import { streamFile } from '../../utilities/stream-fixture';
 
+const commonConfig: Partial<S3HostingConfiguration> = {
+    disableHttpLogging: true
+};
+
 const fixturesDir = join(__dirname, '..', '..');
 
 describe('API Gateway Static Hosting Handler (S3 Host)', () => {
@@ -27,14 +31,15 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
     });
 
     const testBucketName = 'test-bucket';
-    const inlineTestEnvironment: S3HostingConfiguration = {
+    const testConfig: S3HostingConfiguration = {
+        ...commonConfig,
         bucketName: testBucketName
     };
 
     describe('Default Configuration', () => {
         it('Should return 404 if asset directory is set incorrectly', async () => {
             // Arrange
-            const app = new S3Host(inlineTestEnvironment).create();
+            const app = new S3Host(testConfig).create();
             const testFile = '/assets/sample.txt';
 
             s3Mock
@@ -59,15 +64,15 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
         const staticFilePath = 'fixtures';
         const spaIndex = 'outer.html';
 
-        const inlineSpaEnvironment: S3HostingConfiguration = {
-            ...inlineTestEnvironment,
+        const spaConfig: S3HostingConfiguration = {
+            ...testConfig,
             spaIndexPage: spaIndex,
             staticFilePath: staticFilePath
         };
 
         it('Should serve index page for any dynamic route when no asset found', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/my/wild/dynamic/url';
 
             s3Mock
@@ -99,7 +104,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should serve static asset when found', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/assets/sample.txt';
 
             s3Mock
@@ -126,7 +131,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 500 for an S3 error on the intial request', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/my/wild/dynamic/url';
 
             s3Mock
@@ -156,7 +161,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 404 if the SPA index page is missing', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/my/wild/dynamic/url';
 
             s3Mock
@@ -183,7 +188,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 500 if S3 returns no body', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/my/wild/dynamic/url';
 
             s3Mock
@@ -212,7 +217,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 500 for an S3 error on the SPA index page', async () => {
             // Arrange
-            const app = new S3Host(inlineSpaEnvironment).create();
+            const app = new S3Host(spaConfig).create();
             const url = '/my/wild/dynamic/url';
 
             s3Mock
@@ -249,15 +254,15 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
     describe('Not SPA', () => {
         const staticFilePath = 'fixtures';
 
-        const inlineNonSpaEnvironment: S3HostingConfiguration = {
-            ...inlineTestEnvironment,
+        const nonSpaConfig: S3HostingConfiguration = {
+            ...testConfig,
             spaIndexPage: undefined,
             staticFilePath: staticFilePath
         };
 
         it('Should serve static asset when found', async () => {
             // Arrange
-            const app = new S3Host(inlineNonSpaEnvironment).create();
+            const app = new S3Host(nonSpaConfig).create();
             const testAssets = new Map([
                 ['/outer.html', 'outer'],
                 ['/assets/inner.html', 'inner'],
@@ -295,7 +300,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 404 when no static asset found', async () => {
             // Arrange
-            const app = new S3Host(inlineNonSpaEnvironment).create();
+            const app = new S3Host(nonSpaConfig).create();
             const url = '/no/such/file.txt';
 
             s3Mock
@@ -317,7 +322,7 @@ describe('API Gateway Static Hosting Handler (S3 Host)', () => {
 
         it('Should return 500 if S3 returns no body', async () => {
             // Arrange
-            const app = new S3Host(inlineNonSpaEnvironment).create();
+            const app = new S3Host(nonSpaConfig).create();
             const url = '/outer.html';
 
             s3Mock


### PR DESCRIPTION
## Changes

* 🆕 Add configuration option for silencing HTTP request logging in the API Gateway Static Hosting pattern
* 🔄 Silence HTTP request logging for aforementioned pattern in test workflow