### PR TITLE
fix: Friendly Embrace needs RO Permissions to Resources

### DIFF
--- a/API.md
+++ b/API.md
@@ -3428,6 +3428,7 @@ const friendlyEmbraceProps: constructs.FriendlyEmbraceProps = { ... }
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbraceProps.property.encryption">encryption</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | Encryption key for protecting the Lambda environment. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbraceProps.property.ignoreInvalidStates">ignoreInvalidStates</a></code> | <code>boolean</code> | Whether or not stacks in error state should be fatal to CR completion. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbraceProps.property.lambdaConfiguration">lambdaConfiguration</a></code> | <code>@cdklabs/cdk-proserve-lib.types.LambdaConfiguration</code> | Optional Lambda configuration settings. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbraceProps.property.manualReadPermissions">manualReadPermissions</a></code> | <code>aws-cdk-lib.aws_iam.PolicyStatement[]</code> | Manually provide specific read-only permissions for resources in your CloudFormation templates to support instead of using the AWS managed policy [ReadOnlyAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html). |
 
 ---
 
@@ -3476,6 +3477,21 @@ public readonly lambdaConfiguration: LambdaConfiguration;
 - *Type:* @cdklabs/cdk-proserve-lib.types.LambdaConfiguration
 
 Optional Lambda configuration settings.
+
+---
+
+##### `manualReadPermissions`<sup>Optional</sup> <a name="manualReadPermissions" id="@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbraceProps.property.manualReadPermissions"></a>
+
+```typescript
+public readonly manualReadPermissions: PolicyStatement[];
+```
+
+- *Type:* aws-cdk-lib.aws_iam.PolicyStatement[]
+
+Manually provide specific read-only permissions for resources in your CloudFormation templates to support instead of using the AWS managed policy [ReadOnlyAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html).
+
+This can be useful in environments where the caller wants to maintain tight control over the permissions granted
+to the custom resource worker.
 
 ---
 

--- a/test/constructs/friendly-embrace/index.test.ts
+++ b/test/constructs/friendly-embrace/index.test.ts
@@ -31,6 +31,13 @@ describeCdkTest(FriendlyEmbrace, (id, getStack, getTemplate, getApp) => {
                 reason: 'Data is transient and deleted after use. Replication is not necessary.'
             },
             {
+                id: 'AwsSolutions-IAM4',
+                reason: 'Permissions are tightly scoped by CDK grants and otherwise set to the required permissions for updating CloudFormation stacks.',
+                appliesTo: [
+                    'Policy::arn:<AWS::Partition>:iam::aws:policy/ReadOnlyAccess'
+                ]
+            },
+            {
                 id: 'AwsSolutions-IAM5',
                 reason: 'Permissions are tightly scoped by CDK grants and otherwise set to the required permissions for updating CloudFormation stacks.'
             }
@@ -104,22 +111,26 @@ describeCdkTest(FriendlyEmbrace, (id, getStack, getTemplate, getApp) => {
                             'cloudformation:UpdateStack'
                         ],
                         Effect: 'Allow'
-                    }),
-                    Match.objectLike({
-                        Action: [
-                            'dynamodb:DescribeTable',
-                            'ec2:DescribeSecurityGroups',
-                            'ec2:DescribeLaunchTemplates',
-                            'ecs:DescribeServices',
-                            'elasticloadbalancing:DescribeLoadBalancers',
-                            'iam:GetRole',
-                            'logs:DescribeLogGroups',
-                            'sqs:getqueueattributes'
-                        ],
-                        Effect: 'Allow'
                     })
                 ])
             }
+        });
+
+        template.hasResourceProperties('AWS::IAM::Role', {
+            ManagedPolicyArns: [
+                {
+                    'Fn::Join': [
+                        '',
+                        [
+                            'arn:',
+                            {
+                                Ref: 'AWS::Partition'
+                            },
+                            ':iam::aws:policy/ReadOnlyAccess'
+                        ]
+                    ]
+                }
+            ]
         });
     });
 


### PR DESCRIPTION
## Changes
* :bug: Added default `ReadOnlyAccess` AWS managed policy to Friendly Embrace to support CloudFormation templates which may reference any arbitrary properties of resources. Also added an escape hatch for consumers to manually specify their own more tightly scoped permissions instead of using the managed policy