### PR TITLE
fix: firewall routing

### DIFF
--- a/src/constructs/network-firewall/index.ts
+++ b/src/constructs/network-firewall/index.ts
@@ -270,7 +270,7 @@ export class NetworkFirewall extends Construct {
                         routeTableId: returnSubnet.routeTable.routeTableId,
                         destinationCidrBlock: protectedSubnet.ipv4CidrBlock,
                         vpcEndpointId: endpoints.getEndpointId(
-                            returnSubnet.availabilityZone
+                            protectedSubnet.availabilityZone
                         )
                     });
                 }

--- a/test/constructs/network-firewall/index.test.ts
+++ b/test/constructs/network-firewall/index.test.ts
@@ -188,7 +188,7 @@ describeCdkTest(NetworkFirewall, (id, getStack, getTemplate) => {
             VpcEndpointId: {
                 'Fn::GetAtt': [
                     Match.stringLikeRegexp('Endpoints'),
-                    'FirewallStatus.SyncStates.us-east-1c.Attachment.EndpointId'
+                    'FirewallStatus.SyncStates.us-east-1b.Attachment.EndpointId'
                 ]
             }
         });


### PR DESCRIPTION
Fixes the return routing to correctly send traffic to the right firewall endpoint for the AZ it belongs to.