### PR TITLE
feat: Expose the service for Keycloak and allow for env/secret injection

### DIFF
--- a/API.md
+++ b/API.md
@@ -1507,6 +1507,7 @@ Any object.
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.property.adminUser">adminUser</a></code> | <code>aws-cdk-lib.aws_secretsmanager.ISecret</code> | Credentials for bootstrapping a local admin user in Keycloak. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.property.endpoint">endpoint</a></code> | <code>aws-cdk-lib.aws_elasticloadbalancingv2.IApplicationLoadBalancer \| aws-cdk-lib.aws_elasticloadbalancingv2.INetworkLoadBalancer</code> | Endpoint for the Keycloak service. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.property.service">service</a></code> | <code>aws-cdk-lib.aws_ecs.FargateService</code> | Container service for the Keycloak cluster. |
 
 ---
 
@@ -1543,6 +1544,18 @@ public readonly endpoint: IApplicationLoadBalancer | INetworkLoadBalancer;
 - *Type:* aws-cdk-lib.aws_elasticloadbalancingv2.IApplicationLoadBalancer | aws-cdk-lib.aws_elasticloadbalancingv2.INetworkLoadBalancer
 
 Endpoint for the Keycloak service.
+
+---
+
+##### `service`<sup>Optional</sup> <a name="service" id="@cdklabs/cdk-proserve-lib.patterns.KeycloakService.property.service"></a>
+
+```typescript
+public readonly service: FargateService;
+```
+
+- *Type:* aws-cdk-lib.aws_ecs.FargateService
+
+Container service for the Keycloak cluster.
 
 ---
 
@@ -3246,8 +3259,22 @@ const clusterConfiguration: patterns.KeycloakService.ClusterConfiguration = { ..
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | Environment variables to make accessible to the service containers. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.scaling">scaling</a></code> | <code>@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterScalingConfiguration</code> | Boundaries for cluster scaling. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.secrets">secrets</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_ecs.Secret}</code> | Environment variables to make accessible to the service containers via secrets. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.sizing">sizing</a></code> | <code>@cdklabs/cdk-proserve-lib.patterns.KeycloakService.TaskSizingConfiguration</code> | Resource allocation options for each Keycloak task. |
+
+---
+
+##### `environment`<sup>Optional</sup> <a name="environment" id="@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.environment"></a>
+
+```typescript
+public readonly environment: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Environment variables to make accessible to the service containers.
 
 ---
 
@@ -3262,6 +3289,18 @@ public readonly scaling: ClusterScalingConfiguration;
 Boundaries for cluster scaling.
 
 If not specified, auto scaling is disabled
+
+---
+
+##### `secrets`<sup>Optional</sup> <a name="secrets" id="@cdklabs/cdk-proserve-lib.patterns.KeycloakService.ClusterConfiguration.property.secrets"></a>
+
+```typescript
+public readonly secrets: {[ key: string ]: Secret};
+```
+
+- *Type:* {[ key: string ]: aws-cdk-lib.aws_ecs.Secret}
+
+Environment variables to make accessible to the service containers via secrets.
 
 ---
 

--- a/src/patterns/keycloak-service/components/cluster.ts
+++ b/src/patterns/keycloak-service/components/cluster.ts
@@ -179,8 +179,10 @@ export class KeycloakCluster extends Construct {
 
         serviceDefinition.addContainer('Application', {
             image: this.props.image,
-            environment:
-                this.props.dynamicConfigurationBuilder.generateStandardDynamicConfiguration(),
+            environment: {
+                ...this.props.dynamicConfigurationBuilder.generateStandardDynamicConfiguration(),
+                ...this.props.configuration?.environment
+            },
             logging: new AwsLogDriver({
                 logGroup: new LogGroup(this, 'LogDestination', {
                     encryptionKey: this.props.encryption,
@@ -205,8 +207,10 @@ export class KeycloakCluster extends Construct {
                     protocol: Protocol.TCP
                 }
             ],
-            secrets:
-                this.props.dynamicConfigurationBuilder.generateSecureDynamicConfiguration()
+            secrets: {
+                ...this.props.dynamicConfigurationBuilder.generateSecureDynamicConfiguration(),
+                ...this.props.configuration?.secrets
+            }
         });
 
         const service = new FargateService(this, 'Service', {

--- a/src/patterns/keycloak-service/index.ts
+++ b/src/patterns/keycloak-service/index.ts
@@ -4,7 +4,11 @@
 import { Annotations, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { ISubnet, IVpc } from 'aws-cdk-lib/aws-ec2';
-import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import {
+    ContainerImage,
+    Secret as ContainerSecret,
+    FargateService
+} from 'aws-cdk-lib/aws-ecs';
 import {
     ApplicationLoadBalancer,
     IApplicationLoadBalancer,
@@ -202,6 +206,11 @@ export class KeycloakService extends Construct {
     readonly endpoint?: IApplicationLoadBalancer | INetworkLoadBalancer;
 
     /**
+     * Container service for the Keycloak cluster
+     */
+    readonly service?: FargateService;
+
+    /**
      * Create a new Keycloak service
      * @param scope Parent to which this construct belongs
      * @param id Unique identifier for the component
@@ -249,6 +258,8 @@ export class KeycloakService extends Construct {
             this.endpoint = fabric.resources.loadBalancer;
 
             this.configureClusterRequestCountScaling(cluster, fabric);
+
+            this.service = cluster.resources.service;
         }
     }
 
@@ -1007,6 +1018,16 @@ export namespace KeycloakService {
          * Guidance on sizing can be found [here](https://www.keycloak.org/high-availability/concepts-memory-and-cpu-sizing)
          */
         readonly sizing?: TaskSizingConfiguration;
+
+        /**
+         * Environment variables to make accessible to the service containers
+         */
+        readonly environment?: Record<string, string>;
+
+        /**
+         * Environment variables to make accessible to the service containers via secrets
+         */
+        readonly secrets?: Record<string, ContainerSecret>;
     }
 
     /**


### PR DESCRIPTION
## Changes
* Expose the underlying Fargate service for Keycloak to allow for permissions modifications to the container task role
* Allow for environment and secret injection to the Keycloak task definition