### PR TITLE
chore(deps): upgrade aws-cdk-lib to 2.223.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -352,7 +352,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.212.0",
+      "version": "^2.223.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -15,7 +15,7 @@ const project = new CdklabsConstructLibrary({
     private: false,
     keywords: ['aws', 'awscdk', 'aws-cdk', 'cdk'],
     jsiiVersion: '~5.8',
-    cdkVersion: '2.212.0',
+    cdkVersion: '2.223.0',
     defaultReleaseBranch: 'main',
     rosettaOptions: {
         strict: false

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/parser": "^8",
     "@vitest/coverage-v8": "^3.2.7",
     "adm-zip": "0.6.0",
-    "aws-cdk-lib": "2.212.0",
+    "aws-cdk-lib": "2.223.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-vitest": "^6.2.1",
     "cdk-nag": "2.34.0",
@@ -128,7 +128,7 @@
     "vitest": "^3.2.7"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.212.0",
+    "aws-cdk-lib": "^2.223.0",
     "constructs": "^10.0.5"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
     "@aws-cdk/service-spec-types" "^0.0.266"
     "@cdklabs/tskb" "^0.0.4"
 
-"@aws-cdk/cloud-assembly-schema@^48.3.0":
-  version "48.5.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.5.0.tgz#c6f59d69c74c8eeb8f1fe3a479e05d226133963d"
-  integrity sha512-IH9KWy+Cxz9v/1h0qfbviXhhXFH86wV+lUHB2EKA0Sum0E1nGBM0jCgJjhdw809Mu/Xta+ggE2ceoSG4sftTCA==
+"@aws-cdk/cloud-assembly-schema@^48.6.0":
+  version "48.20.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz#a2b60373cfbe228f901f62f0d7e2c5e2fe40702d"
+  integrity sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==
   dependencies:
     jsonschema "~1.4.1"
     semver "^7.7.2"
@@ -3707,14 +3707,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.212.0:
-  version "2.212.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.212.0.tgz#a7b2ed75e80255b75d34795b4e8d7fa2e97a8b40"
-  integrity sha512-7vy3/fSwmkJe6hmPpX2DXeDIr/VhMjhOPRH4Y0IUjC0c+W6S4XwQU2urRq3DFJRKRWXDwKidqMZlF1m0ZY1wMw==
+aws-cdk-lib@2.223.0:
+  version "2.223.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.223.0.tgz#5ff8f723dc7dad3e446c17861de2a24fb35e2be7"
+  integrity sha512-UCSsBs3d6nAuXpx+nSQM6DmEHHOwVCbzItPmByh/Irx2V8vjPqLrjR3RDYbMWRv0u1bxK/YEjuzwnts8uYS7UQ==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "2.2.242"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^48.3.0"
+    "@aws-cdk/cloud-assembly-schema" "^48.6.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.3.1"


### PR DESCRIPTION
## What

Bumps the library's `cdkVersion` (peer + build version) from **2.212.0 → 2.223.0** in `.projenrc.ts`. `package.json`, `.projen/deps.json`, and `yarn.lock` are regenerated by `npx projen`. No source changes.

## Why 2.223.0 (and not 2.260.0 as Dependabot proposed)

This repo is projen-managed, so the aws-cdk-lib version lives in `.projenrc.ts` — Dependabot's `package.json`-only edit is reverted by `npx projen` and fails the build's self-mutation gate. Beyond that mechanism, the target version matters:

- **≤ 2.223.0** — zero code changes, `constructs` peer floor unchanged (`^10.0.5`), cdk-nag `AwsSolutions-L1` green.
- **2.224.0–2.238.0** — aws-cdk-lib adds `nodejs24.x` to its runtime catalog, so cdk-nag L1 flags every hardcoded `NODEJS_22_X`; adopting these requires migrating all provisioned Lambdas Node 22→24 (a consumer-visible deployment change).
- **≥ 2.239.0** — the above **and** raises the published `constructs` peer floor to `^10.5.0` (drops consumers on constructs 10.0.x–10.4.x and expands the jsii API surface).

2.223.0 is the highest version that requires no code changes and no peer-floor change, capturing 11 minor versions with zero blast radius. Adopting ≥ 2.224.0 is deliberately deferred to a separate, scoped effort (its real content is the Node 22→24 runtime migration, which deserves its own PR and sign-off).

Closes #242.

## Validation

- `npx projen build`: **589/589 tests pass** across 65 files; compile (jsii), docgen, rosetta, esbuild, eslint, integ all clean.
- **Self-mutation gate clean**: `git status --porcelain` empty after building the committed tree.
- **Zero** snapshot or doc changes; `API.md` untouched (constructs floor unchanged).
