### PR TITLE
feat!: adopt aws-cdk-lib 2.265.0 and migrate Lambda runtimes to Node.js 24

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -352,12 +352,12 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.223.0",
+      "version": "^2.265.0",
       "type": "peer"
     },
     {
       "name": "constructs",
-      "version": "^10.0.5",
+      "version": "^10.5.0",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -15,7 +15,10 @@ const project = new CdklabsConstructLibrary({
     private: false,
     keywords: ['aws', 'awscdk', 'aws-cdk', 'cdk'],
     jsiiVersion: '~5.8',
-    cdkVersion: '2.223.0',
+    cdkVersion: '2.265.0',
+    // Must stay >= the constructs peer that cdkVersion declares; jsii fails the
+    // build if the installed constructs is below it.
+    constructsVersion: '10.5.0',
     defaultReleaseBranch: 'main',
     rosettaOptions: {
         strict: false

--- a/API.md
+++ b/API.md
@@ -94,6 +94,7 @@ Metadata for configuring the pattern.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.ApiGatewayStaticHosting.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.ApiGatewayStaticHosting.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -104,6 +105,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.patterns.ApiGatewayStaticHosting.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.patterns.ApiGatewayStaticHosting.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -319,6 +341,7 @@ Metadata for configuring the Custom Resource.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.DynamoDbProvisionTable.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.DynamoDbProvisionTable.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -329,6 +352,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.DynamoDbProvisionTable.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.DynamoDbProvisionTable.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -456,6 +500,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderGetImage.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderGetImage.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -466,6 +511,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderGetImage.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderGetImage.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -618,6 +684,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderStart.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderStart.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -628,6 +695,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderStart.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImageBuilderStart.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -777,6 +865,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -787,6 +876,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.Ec2ImagePipeline.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -975,6 +1085,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -985,6 +1096,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.patterns.Ec2LinuxImagePipeline.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1174,6 +1306,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbrace.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbrace.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -1184,6 +1317,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbrace.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.FriendlyEmbrace.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1350,6 +1504,7 @@ Metadata for configuring the Custom Resource.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.IamServerCertificate.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.IamServerCertificate.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -1360,6 +1515,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.IamServerCertificate.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.IamServerCertificate.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1575,6 +1751,7 @@ Properties for configuring the cluster for Keycloak.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.patterns.KeycloakService.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -1585,6 +1762,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.patterns.KeycloakService.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.patterns.KeycloakService.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1753,6 +1951,7 @@ Network Firewall configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.NetworkFirewall.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.NetworkFirewall.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -1763,6 +1962,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.NetworkFirewall.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.NetworkFirewall.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1908,6 +2128,7 @@ Configuration properties for the construct.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.getEndpointId">getEndpointId</a></code> | Gets the endpoint ID for a specific availability zone. |
 
 ---
@@ -1919,6 +2140,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 ##### `getEndpointId` <a name="getEndpointId" id="@cdklabs/cdk-proserve-lib.constructs.NetworkFirewallEndpoints.getEndpointId"></a>
 
@@ -2086,6 +2328,7 @@ Metadata for configuring the custom resource.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchAdminUser.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchAdminUser.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -2096,6 +2339,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchAdminUser.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchAdminUser.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -2304,6 +2568,7 @@ Metadata for configuring the Custom Resource.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchProvisionDomain.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchProvisionDomain.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -2314,6 +2579,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchProvisionDomain.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchProvisionDomain.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -2461,6 +2747,7 @@ Metadata for configuring the custom resource.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.getResourceId">getResourceId</a></code> | Retrieves a created Resource ID from the Workflow by the provided workflowStepId. |
 
 ---
@@ -2472,6 +2759,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 ##### `getResourceId` <a name="getResourceId" id="@cdklabs/cdk-proserve-lib.constructs.OpenSearchWorkflow.getResourceId"></a>
 
@@ -2667,6 +2975,7 @@ Configuration properties.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.with">with</a></code> | Applies one or more mixins to this construct. |
 | <code><a href="#@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.associate">associate</a></code> | Associates the Web Application Firewall to an applicable resource. |
 
 ---
@@ -2678,6 +2987,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
 
 ##### `associate` <a name="associate" id="@cdklabs/cdk-proserve-lib.constructs.WebApplicationFirewall.associate"></a>
 

--- a/package.json
+++ b/package.json
@@ -91,14 +91,14 @@
     "@typescript-eslint/parser": "^8",
     "@vitest/coverage-v8": "^3.2.7",
     "adm-zip": "0.6.0",
-    "aws-cdk-lib": "2.223.0",
+    "aws-cdk-lib": "2.265.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-vitest": "^6.2.1",
     "cdk-nag": "2.34.0",
     "cdklabs-projen-project-types": "^0.3.12",
     "cloudform-types": "^7.5.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.0.5",
+    "constructs": "10.5.0",
     "esbuild": "^0.28.2",
     "eslint": "^9",
     "eslint-config-prettier": "^9.1.2",
@@ -128,8 +128,8 @@
     "vitest": "^3.2.7"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.223.0",
-    "constructs": "^10.0.5"
+    "aws-cdk-lib": "^2.265.0",
+    "constructs": "^10.5.0"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",

--- a/src/aspects/ec2-automated-shutdown/index.ts
+++ b/src/aspects/ec2-automated-shutdown/index.ts
@@ -177,7 +177,7 @@ export class Ec2AutomatedShutdown implements IAspect {
         if (!Ec2AutomatedShutdown.lambdaByStack.has(stackId)) {
             const lambda = new SecureFunction(stack, 'Ec2ShutdownFunction', {
                 code: Code.fromAsset(join(__dirname, 'handler')),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 handler: 'index.handler',
                 timeout: Duration.seconds(15),
                 encryption: this.props.encryption,

--- a/src/aspects/rds-oracle-multi-tenant/index.ts
+++ b/src/aspects/rds-oracle-multi-tenant/index.ts
@@ -225,7 +225,7 @@ export class RdsOracleMultiTenant implements IAspect {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(5),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 ...lambdaConfig
             });
 
@@ -239,7 +239,7 @@ export class RdsOracleMultiTenant implements IAspect {
                     handler: 'index.handler',
                     memorySize: 512,
                     timeout: Duration.minutes(5),
-                    runtime: Runtime.NODEJS_22_X,
+                    runtime: Runtime.NODEJS_24_X,
                     ...lambdaConfig
                 }
             );

--- a/src/constructs/dynamodb-provision-table/index.ts
+++ b/src/constructs/dynamodb-provision-table/index.ts
@@ -130,7 +130,7 @@ export class DynamoDbProvisionTable extends Construct {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(1),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 encryption: props.encryption,
                 ...props.lambdaConfiguration
             });

--- a/src/constructs/ec2-image-builder-start/index.ts
+++ b/src/constructs/ec2-image-builder-start/index.ts
@@ -180,7 +180,7 @@ export class Ec2ImageBuilderStart extends Construct {
 
             const signal = new SecureFunction(this, 'WaiterSignal', {
                 code: Code.fromAsset(join(__dirname, 'handler')),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 handler: 'index.handler',
                 environment: {
                     WAIT_HANDLE_URL: waitHandle.ref,

--- a/src/constructs/friendly-embrace/index.ts
+++ b/src/constructs/friendly-embrace/index.ts
@@ -148,7 +148,7 @@ export class FriendlyEmbrace extends Construct {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(5),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 environment: {
                     CFN_TEMPLATE_BUCKET_NAME: cfnTemplateBucket.bucketName,
                     CFN_TEMPLATE_BUCKET_URL: cfnTemplateBucket.urlForObject()

--- a/src/constructs/iam-server-certificate/index.ts
+++ b/src/constructs/iam-server-certificate/index.ts
@@ -136,7 +136,7 @@ export class IamServerCertificate extends Construct {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(1),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 encryption: props.encryption,
                 ...props.lambdaConfiguration
             });

--- a/src/constructs/opensearch-admin-user/index.ts
+++ b/src/constructs/opensearch-admin-user/index.ts
@@ -130,7 +130,7 @@ export class OpenSearchAdminUser extends Construct {
                 code: Code.fromAsset(join(__dirname, 'handler', 'on-event')),
                 handler: 'index.handler',
                 timeout: Duration.minutes(1),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 encryption: props.encryption,
                 ...props.lambdaConfiguration
             });

--- a/src/constructs/opensearch-provision-domain/index.ts
+++ b/src/constructs/opensearch-provision-domain/index.ts
@@ -201,7 +201,7 @@ export class OpenSearchProvisionDomain extends Construct {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(5),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 encryption: props.encryption,
                 ...props.lambdaConfiguration
             });

--- a/src/constructs/opensearch-workflow/index.ts
+++ b/src/constructs/opensearch-workflow/index.ts
@@ -146,7 +146,7 @@ export class OpenSearchWorkflow extends Construct {
                 handler: 'index.handler',
                 memorySize: 512,
                 timeout: Duration.minutes(5),
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 encryption: props.encryption,
                 ...props.lambdaConfiguration
             });
@@ -161,7 +161,7 @@ export class OpenSearchWorkflow extends Construct {
                     handler: 'index.handler',
                     memorySize: 512,
                     timeout: Duration.minutes(5),
-                    runtime: Runtime.NODEJS_22_X,
+                    runtime: Runtime.NODEJS_24_X,
                     encryption: props.encryption,
                     ...props.lambdaConfiguration
                 }

--- a/src/patterns/apigateway-static-hosting/index.ts
+++ b/src/patterns/apigateway-static-hosting/index.ts
@@ -384,7 +384,7 @@ export class ApiGatewayStaticHosting extends Construct {
             handler: 'index.handler',
             memorySize: 512,
             timeout: Duration.seconds(29),
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             encryption: this.props.encryption,
             environment: {
                 CONFIGURATION: JSON.stringify(config)

--- a/test/aspects/create-lambda-log-group/index.test.ts
+++ b/test/aspects/create-lambda-log-group/index.test.ts
@@ -29,7 +29,7 @@ describeCdkTest(CreateLambdaLogGroup, (_, getStack, getTemplate) => {
     it('should create log group when visiting a Lambda function', () => {
         // Arrange
         new Function(stack, 'TestFunction', {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = () => {};'),
             reservedConcurrentExecutions: 5

--- a/test/aspects/ec2-automated-shutdown/index.test.ts
+++ b/test/aspects/ec2-automated-shutdown/index.test.ts
@@ -115,7 +115,7 @@ describeCdkTest(Ec2AutomatedShutdown, (_, getStack, getTemplate) => {
         template.hasResource('AWS::Lambda::Function', {
             Properties: Match.objectLike({
                 Handler: 'index.handler',
-                Runtime: 'nodejs22.x'
+                Runtime: 'nodejs24.x'
             })
         });
 

--- a/test/aspects/rds-oracle-multi-tenant/index.test.ts
+++ b/test/aspects/rds-oracle-multi-tenant/index.test.ts
@@ -727,7 +727,7 @@ describeCdkTest(RdsOracleMultiTenant, (_, getStack, getTemplate, getApp) => {
 
             template.hasResourceProperties('AWS::Lambda::Function', {
                 Handler: 'index.handler',
-                Runtime: 'nodejs22.x'
+                Runtime: 'nodejs24.x'
             });
 
             template.resourceCountIs('AWS::Lambda::Function', 5);
@@ -792,7 +792,7 @@ describeCdkTest(RdsOracleMultiTenant, (_, getStack, getTemplate, getApp) => {
             const template = getTemplate();
 
             template.hasResourceProperties('AWS::Lambda::Function', {
-                Runtime: 'nodejs22.x',
+                Runtime: 'nodejs24.x',
                 Handler: 'index.handler',
                 Timeout: 300
             });

--- a/test/aspects/security-compliance/visitors/settings/lambda.test.ts
+++ b/test/aspects/security-compliance/visitors/settings/lambda.test.ts
@@ -19,7 +19,7 @@ describeCdkTest(SecurityCompliance, (_, getStack, getTemplate) => {
         it('does not apply reserved concurrency if disabled', () => {
             // Arrange
             new SecureFunction(stack, 'TestFunction', {
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 handler: 'index.handler',
                 code: Code.fromInline('exports.handler = () => {};')
             });
@@ -48,7 +48,7 @@ describeCdkTest(SecurityCompliance, (_, getStack, getTemplate) => {
         it('applies default reserved concurrent executions', () => {
             // Arrange
             new SecureFunction(stack, 'TestFunction', {
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 handler: 'index.handler',
                 code: Code.fromInline('exports.handler = () => {};'),
                 reservedConcurrentExecutions: undefined
@@ -67,7 +67,7 @@ describeCdkTest(SecurityCompliance, (_, getStack, getTemplate) => {
         it('sets a user defined reserved concurrent execution', () => {
             // Arrange
             new SecureFunction(stack, 'TestFunction', {
-                runtime: Runtime.NODEJS_22_X,
+                runtime: Runtime.NODEJS_24_X,
                 handler: 'index.handler',
                 code: Code.fromInline('exports.handler = () => {};'),
                 reservedConcurrentExecutions: undefined

--- a/test/aspects/set-log-retention/index.test.ts
+++ b/test/aspects/set-log-retention/index.test.ts
@@ -48,7 +48,7 @@ describeCdkTest(SetLogRetention, (_, getStack, getTemplate) => {
     it('should set retention on custom resource log retention', () => {
         // Arrange
         const func = new Function(stack, 'TestFunction', {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = () => {};'),
             reservedConcurrentExecutions: 5

--- a/test/constructs/dynamodb-provision-table/index.test.ts
+++ b/test/constructs/dynamodb-provision-table/index.test.ts
@@ -68,7 +68,7 @@ describeCdkTest(DynamoDbProvisionTable, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };

--- a/test/constructs/friendly-embrace/index.test.ts
+++ b/test/constructs/friendly-embrace/index.test.ts
@@ -66,7 +66,7 @@ describeCdkTest(FriendlyEmbrace, (id, getStack, getTemplate, getApp) => {
         template = getTemplate();
         template.hasResourceProperties('AWS::Lambda::Function', {
             Handler: 'index.handler',
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 300,
             MemorySize: 512
         });

--- a/test/constructs/iam-server-certificate/index.test.ts
+++ b/test/constructs/iam-server-certificate/index.test.ts
@@ -126,7 +126,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };
@@ -185,7 +185,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };
@@ -270,7 +270,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };
@@ -348,7 +348,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };
@@ -411,7 +411,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };
@@ -474,7 +474,7 @@ describeCdkTest(IamServerCertificate, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60,
             MemorySize: 512
         };

--- a/test/constructs/opensearch-admin-user/index.test.ts
+++ b/test/constructs/opensearch-admin-user/index.test.ts
@@ -103,7 +103,7 @@ describeCdkTest(OpenSearchAdminUser, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60
         };
 
@@ -147,7 +147,7 @@ describeCdkTest(OpenSearchAdminUser, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 60
         };
 

--- a/test/constructs/opensearch-provision-domain/index.test.ts
+++ b/test/constructs/opensearch-provision-domain/index.test.ts
@@ -103,7 +103,7 @@ describeCdkTest(OpenSearchProvisionDomain, (id, getStack, getTemplate) => {
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
             ReservedConcurrentExecutions: 5,
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 300,
             MemorySize: 512
         };

--- a/test/constructs/opensearch-workflow/index.test.ts
+++ b/test/constructs/opensearch-workflow/index.test.ts
@@ -58,7 +58,7 @@ describeCdkTest(OpenSearchWorkflow, (id, getStack, getTemplate) => {
 
         const lambdaResourceProperties: Partial<FunctionProperties> = {
             Handler: 'index.handler',
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             Timeout: 300 // 5 minutes
         };
 

--- a/test/constructs/secure-function/index.test.ts
+++ b/test/constructs/secure-function/index.test.ts
@@ -20,7 +20,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
     it('creates lambda function with default properties', () => {
         // Act
         new SecureFunction(stack, id, {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = function() { }')
         });
@@ -30,7 +30,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
 
         template.hasResourceProperties('AWS::Lambda::Function', {
             Handler: 'index.handler',
-            Runtime: 'nodejs22.x',
+            Runtime: 'nodejs24.x',
             ReservedConcurrentExecutions: 5
         });
 
@@ -58,7 +58,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
     it('creates lambda function with custom log retention', () => {
         // Act
         new SecureFunction(stack, id, {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = function() { }'),
             logGroupRetention: RetentionDays.ONE_WEEK
@@ -78,7 +78,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
 
         // Act
         new SecureFunction(stack, id, {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = function() { }'),
             encryption: key
@@ -105,7 +105,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
     it('grants log write permissions to lambda', () => {
         // Act
         new SecureFunction(stack, id, {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = function() { }')
         });
@@ -139,7 +139,7 @@ describeCdkTest(SecureFunction, (id, getStack, getTemplate) => {
 
         // Act
         new SecureFunction(stack, id, {
-            runtime: Runtime.NODEJS_22_X,
+            runtime: Runtime.NODEJS_24_X,
             handler: 'index.handler',
             code: Code.fromInline('exports.handler = function() { }'),
             encryption: key

--- a/test/patterns/apigateway-static-hosting/backend.test.ts
+++ b/test/patterns/apigateway-static-hosting/backend.test.ts
@@ -97,7 +97,7 @@ describeCdkTest(ApiGatewayStaticHosting, (id, getStack, getTemplate) => {
                 Handler: 'index.handler',
                 MemorySize: 512,
                 ReservedConcurrentExecutions: 5,
-                Runtime: 'nodejs22.x',
+                Runtime: 'nodejs24.x',
                 Timeout: 29
             };
             const handlerPolicy: Partial<PolicyProperties> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,15 +10,15 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/asset-awscli-v1@2.2.242":
-  version "2.2.242"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz#235cb25b6d1ad26975b0095c0d6ee84309adae5c"
-  integrity sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==
+"@aws-cdk/asset-awscli-v1@2.2.292":
+  version "2.2.292"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz#caa029bbe15199606f39877c68bf5880b1f59869"
+  integrity sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==
 
-"@aws-cdk/asset-node-proxy-agent-v6@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
-  integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
+"@aws-cdk/asset-node-proxy-agent-v6@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz#71733894b092032309523cfcba24dc2bb3e7fd84"
+  integrity sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==
 
 "@aws-cdk/aws-service-spec@0.1.200":
   version "0.1.200"
@@ -28,13 +28,22 @@
     "@aws-cdk/service-spec-types" "^0.0.266"
     "@cdklabs/tskb" "^0.0.4"
 
-"@aws-cdk/cloud-assembly-schema@^48.6.0":
-  version "48.20.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz#a2b60373cfbe228f901f62f0d7e2c5e2fe40702d"
-  integrity sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==
+"@aws-cdk/cloud-assembly-api@^2.2.6":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.3.0.tgz#fe1027594ea171cfed154ef8438b3b29fe4e1e93"
+  integrity sha512-Z+TYWH9YJGDQSwjORTWvfRFHGK5Gzdp73ElVO8mmZrgndlZgNV2LJOcX1HYRlU/OuR7I+Qo5GLpfc/PM1s7JlQ==
   dependencies:
-    jsonschema "~1.4.1"
-    semver "^7.7.2"
+    json-source-map "^0.6.1"
+    jsonschema "^1.5.0"
+    semver "^7.8.5"
+
+"@aws-cdk/cloud-assembly-schema@^54.11.0":
+  version "54.19.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.19.0.tgz#5e633a61db4dcd621ccecc91a626bd94da8f395d"
+  integrity sha512-o0axGGePF7NHFv3uIjKpfgMIQ8hG6U5gg629aNmE4+l08MndUKYaya3swhP3WoOKbxisVX3bVsrhnksN0NFoag==
+  dependencies:
+    jsonschema "^1.5.0"
+    semver "^7.8.5"
 
 "@aws-cdk/integ-runner@latest":
   version "2.204.4"
@@ -1383,6 +1392,11 @@
   dependencies:
     "@smithy/types" "^4.16.1"
     tslib "^2.6.2"
+
+"@aws/cloudformation-validate@1.7.0-beta":
+  version "1.7.0-beta"
+  resolved "https://registry.yarnpkg.com/@aws/cloudformation-validate/-/cloudformation-validate-1.7.0-beta.tgz#37704db3ca54b2e1edf012d78d042b39946e157f"
+  integrity sha512-3ucys2VE2plAVijHHJmDpDDdi6gxXc/x0bvU3W8Fdm2dZF7Ewb0oQbBTLfrcPCkeHKFpfJtTtfOUl4w6J6uB6w==
 
 "@aws/lambda-invoke-store@^0.3.0":
   version "0.3.0"
@@ -3520,16 +3534,6 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
 ansi-escapes@^7.0.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
@@ -3685,11 +3689,6 @@ ast-v8-to-istanbul@^0.3.3:
     estree-walker "^3.0.3"
     js-tokens "^10.0.0"
 
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
 async-function@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
@@ -3707,25 +3706,26 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.223.0:
-  version "2.223.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.223.0.tgz#5ff8f723dc7dad3e446c17861de2a24fb35e2be7"
-  integrity sha512-UCSsBs3d6nAuXpx+nSQM6DmEHHOwVCbzItPmByh/Irx2V8vjPqLrjR3RDYbMWRv0u1bxK/YEjuzwnts8uYS7UQ==
+aws-cdk-lib@2.265.0:
+  version "2.265.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz#da9154de47b9a061658ac3595cbf77092e989d5f"
+  integrity sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "2.2.242"
-    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^48.6.0"
+    "@aws-cdk/asset-awscli-v1" "2.2.292"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.2"
+    "@aws-cdk/cloud-assembly-api" "^2.2.6"
+    "@aws-cdk/cloud-assembly-schema" "^54.11.0"
+    "@aws/cloudformation-validate" "1.7.0-beta"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^11.3.1"
+    fs-extra "^11.3.6"
     ignore "^5.3.2"
     jsonschema "^1.5.0"
     mime-types "^2.1.35"
-    minimatch "^3.1.2"
+    minimatch "^10.2.5"
     punycode "^2.3.1"
-    semver "^7.7.2"
-    table "^6.9.0"
-    yaml "1.10.2"
+    semver "^7.8.5"
+    yaml "1.10.3"
 
 aws-sdk-client-mock-vitest@^6.2.1:
   version "6.2.1"
@@ -4091,10 +4091,10 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-constructs@10.0.5:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.5.tgz#48c0402f1b98bbf5664efff74a8015e6e8a9f41e"
-  integrity sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==
+constructs@10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.5.0.tgz#66d1a5fb748f4adeb8698ea5f53f27e06f99b930"
+  integrity sha512-zWjwqIgk4nAWmQGrPnDWv+M2Yly6m7ROyqmmQVLgJiHnWP762It22uWFaF2Pu/sSx0u8WsoUcvt0PZ4DQIQYwQ==
 
 constructs@^10.0.0:
   version "10.4.4"
@@ -4987,11 +4987,6 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
-
 fast-xml-builder@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz#ef05b353b45597483dfb09d450a062a2baec3a82"
@@ -5161,10 +5156,10 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.3.1:
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.1.tgz#ba7a1f97a85f94c6db2e52ff69570db3671d5a74"
-  integrity sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==
+fs-extra@^11.3.6:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.4.0.tgz#f88ed6d180ac9e14b61b08e679468f0b1b6b4730"
+  integrity sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -6056,10 +6051,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+json-source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
+  integrity sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -6108,11 +6103,6 @@ jsonschema@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
   integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
-
-jsonschema@~1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
-  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 just-diff-apply@^5.2.0:
   version "5.5.0"
@@ -6236,11 +6226,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 log-update@^6.1.0:
   version "6.1.0"
@@ -6448,7 +6433,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^10.2.2:
+minimatch@^10.2.2, minimatch@^10.2.5:
   version "10.2.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
   integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
@@ -7154,11 +7139,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -7496,15 +7476,6 @@ sinon@^18.0.1:
     nise "^6.0.0"
     supports-color "^7"
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 slice-ansi@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
@@ -7802,17 +7773,6 @@ synckit@^0.11.13:
   integrity sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==
   dependencies:
     "@pkgr/core" "^0.3.6"
-
-table@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
-  integrity sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
 
 test-exclude@^7.0.1:
   version "7.0.2"
@@ -8337,10 +8297,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yaml@^2.2.2, yaml@^2.8.2:
   version "2.8.2"


### PR DESCRIPTION
## What

Adopts the latest AWS CDK and clears the Node-runtime "hump" that blocked bumping past `aws-cdk-lib` 2.223.0:

- `cdkVersion` **2.223.0 → 2.265.0** (current latest)
- `constructsVersion` → **10.5.0** (the minimum floor `aws-cdk-lib@2.265.0` requires)
- Migrates **all 12 Lambda runtimes** this library provisions from `NODEJS_22_X` → `NODEJS_24_X` (across 10 `src/` files), plus the corresponding test assertions/fixtures (13 test files).

Explicit `NODEJS_24_X` is used (not `NODEJS_LATEST`, which is a moving target that would silently change deployed runtimes and re-trip cdk-nag `AwsSolutions-L1` on every future CDK bump).

## Why it couldn't be a plain dep bump

`aws-cdk-lib >= 2.224.0` adds `nodejs24.x` to its runtime catalog, so cdk-nag `AwsSolutions-L1` ("use the latest runtime") fires on every hardcoded `NODEJS_22_X`. Adopting current CDK therefore *requires* the runtime migration. `>= 2.239.0` additionally raises the published `constructs` peer floor to `^10.5.0`.

## ⚠️ BREAKING CHANGE

This ships **two** distinct breaking changes:

1. **Raised minimum peers** — `aws-cdk-lib ^2.212.0 → ^2.265.0` and `constructs ^10.0.5 → ^10.5.0`. Consumers below those must upgrade to adopt this version.
2. **Deployed Lambda runtime change** — every function this library provisions flips `nodejs22.x → nodejs24.x`. Consumers will see this on their **next `cdk deploy`**, with **no opt-out** (the runtime is hardcoded, not exposed as a prop).

> Possible follow-up (not in this PR): expose an optional `runtime` prop defaulting to `NODEJS_24_X` so consumers can pin/override. That's a design change beyond adopting current CDK.

## Validation

- `npx projen build`: **589/589 tests pass** (65/65 files); compile (jsii), docgen, rosetta, esbuild, eslint, integ all clean. Handler unit tests were also executed locally under Node 24.
- **cdk-nag: zero findings** — grep of the build log for `AwsSolutions-*` returns no matches. The 67 L1 failures seen when attempting a naive 2.260.0 bump are fully resolved.
- **Self-mutation gate clean** — `git status --porcelain` empty after building the committed tree.
- `API.md` grows **+330 / -0** lines: purely additive, the inherited `with(...mixins)` method (30 blocks, one per exported construct) that `constructs` 10.5.0 adds. No API removed.

## Notes

- `examples/` untouched.
- `src/aspects/security-compliance/index.ts` has a `NODEJS_18_X` reference inside a **doc-comment example** (illustrating a consumer's own function, not something this library provisions). Left as-is; it's now stale and could be refreshed separately.

Opening for review — **not** to be merged without sign-off, given the breaking runtime change.
